### PR TITLE
Add missing docstrings

### DIFF
--- a/vortexclust/analysis/decomposition.py
+++ b/vortexclust/analysis/decomposition.py
@@ -118,5 +118,16 @@ def compute_eeof(signal, M=400, n_components=9):
 
 
 def multivariate_autocorrelation(X, lag=1):
+    r"""
+    Computes the autocorrelation for each column in a multivariate time series.
+
+    :param X: Input data containing multiple time series.
+    :type X: array-like or pandas.DataFrame
+    :param lag: Lag at which to compute the autocorrelation, defaults to 1.
+    :type lag: int, optional
+
+    :return: List with the autocorrelation for each column.
+    :rtype: list[float]
+    """
     X = pd.DataFrame(X)
     return [X[col].autocorr(lag=lag) for col in X.columns]

--- a/vortexclust/config.py
+++ b/vortexclust/config.py
@@ -44,6 +44,14 @@ VERBOSE = True
 
 # === Utility Functions === #
 def set_debug_mode(enabled: bool = True):
+    r"""
+    Toggle debug logging for the package.
+
+    :param enabled: Whether to enable debug mode, defaults to True.
+    :type enabled: bool, optional
+
+    :return: None
+    """
     global DEBUG_MODE
     DEBUG_MODE = enabled
     logger.setLevel(logging.DEBUG if enabled else LOG_LEVEL)

--- a/vortexclust/core/utils.py
+++ b/vortexclust/core/utils.py
@@ -50,6 +50,17 @@ def validate_columns(df: pd.DataFrame, required_cols: List[str]) -> None:
 
 # Build candidate event ranges
 def get_event_ranges(flag_array, days=7):
+    r"""
+    Build candidate event ranges from a boolean flag array.
+
+    :param flag_array: Boolean array indicating event days.
+    :type flag_array: array-like
+    :param days: Minimum consecutive days to qualify as an event, defaults to 7.
+    :type days: int, optional
+
+    :return: List of tuples with start and end indices of detected events.
+    :rtype: list[tuple]
+    """
     ranges = []
     i = 0
     while i <= len(flag_array) - days:

--- a/vortexclust/visualization/map.py
+++ b/vortexclust/visualization/map.py
@@ -264,8 +264,21 @@ def plot_polar_stereo(
             # cbar.set_label('Geopotential Height (gpm)')
 
 
-# To Do Doc string
 def plot_split(ax, sample, filled, color='red'):
+    r"""
+    Plot a split vortex event with mother and daughter ellipses.
+
+    :param ax: Axis on which to draw the ellipses.
+    :type ax: matplotlib.axes.Axes
+    :param sample: Data containing ellipse parameters for the split event.
+    :type sample: pandas.Series or dict-like
+    :param filled: Whether to fill the ellipses.
+    :type filled: bool
+    :param color: Color used for the ellipses, defaults to 'red'.
+    :type color: str, optional
+
+    :return: None
+    """
     # plot mother vortex
     x_final, y_final, _ = compute_ellipse(sample.area, sample.ar, sample.theta, sample.loncent, sample.latcent)
     ax.plot(x_final, y_final, linestyle='-.', color=color, label='Mother vortex')

--- a/vortexclust/visualization/utils.py
+++ b/vortexclust/visualization/utils.py
@@ -126,6 +126,14 @@ def create_animation(df: pd.DataFrame, time_col: str, filled: bool,
     fig = plt.figure(figsize=figsize)
 
     def update(frame):
+        r"""
+        Update function for each frame of the animation.
+
+        :param frame: Index of the current frame.
+        :type frame: int
+
+        :return: None
+        """
         fig.clf()  # clear the figure entirely
 
         fig.suptitle(str(df.iloc[frame][time_col]))

--- a/vortexclust/workflows/demo.py
+++ b/vortexclust/workflows/demo.py
@@ -71,6 +71,36 @@ def plot_timeseries_moments(df, columns, labels,
                             positions=None, vertical_line=None,
                             title=None, savefig=None,
                             num_plots=2, figsize=(10, 5)):
+    r"""
+    Plot multiple time series in paired subplots with optional annotations.
+
+    :param df: DataFrame containing the time series data.
+    :type df: pandas.DataFrame
+    :param columns: List of column names to plot. Must contain an even number of entries.
+    :type columns: list
+    :param labels: Labels for each column.
+    :type labels: list
+    :param time_column: Name of the column containing datetime values, defaults to 'string'.
+    :type time_column: str, optional
+    :param time_format: Format string for displaying dates, defaults to '%m-%y'.
+    :type time_format: str, optional
+    :param time_span: Number of rows to include from the start; -1 uses all rows, defaults to -1.
+    :type time_span: int, optional
+    :param positions: Positions at which vertical markers and top labels are drawn, defaults to None.
+    :type positions: list, optional
+    :param vertical_line: Position of a single vertical line, defaults to None.
+    :type vertical_line: int, optional
+    :param title: Title for the figure, defaults to None.
+    :type title: str, optional
+    :param savefig: Path to save the figure, defaults to None.
+    :type savefig: str, optional
+    :param num_plots: Number of subplots to create, defaults to 2.
+    :type num_plots: int, optional
+    :param figsize: Figure size, defaults to (10, 5).
+    :type figsize: tuple, optional
+
+    :return: None
+    """
     if figsize:
         fig, axes = plt.subplots(num_plots, figsize=figsize)
     else:
@@ -122,6 +152,20 @@ def plot_timeseries_moments(df, columns, labels,
 
 
 def plot_eeof(epc, eeof, expl_var_ratio, savefig=None):
+    r"""
+    Visualize extended empirical orthogonal functions and related statistics.
+
+    :param epc: Extended principal components.
+    :type epc: numpy.ndarray
+    :param eeof: Extended empirical orthogonal functions.
+    :type eeof: numpy.ndarray
+    :param expl_var_ratio: Explained variance ratios for the components.
+    :type expl_var_ratio: array-like
+    :param savefig: Path to save the figure, defaults to None.
+    :type savefig: str, optional
+
+    :return: None
+    """
     fig, ax = plt.subplots(2, 2, figsize=(10, 8))
     ax[0][0].scatter(np.arange(1, len(expl_var_ratio)+1), expl_var_ratio*100)
     ax[0][0].set_ylabel('Eigenvalues (%)')
@@ -155,6 +199,20 @@ def plot_eeof(epc, eeof, expl_var_ratio, savefig=None):
 
 
 def plot_hist_per_class(df, feat_k, y, savefig=None):
+    r"""
+    Plot feature histograms grouped by class labels.
+
+    :param df: DataFrame containing the data and class labels.
+    :type df: pandas.DataFrame
+    :param feat_k: Dictionary-like object with a list of feature names under ``'features'``.
+    :type feat_k: dict
+    :param y: Column name of the class variable.
+    :type y: str
+    :param savefig: Path to save the figure, defaults to None.
+    :type savefig: str, optional
+
+    :return: None
+    """
     # for idx, feat_k in enumerate(features_kopt):
     var = y
     for feature in feat_k['features']:


### PR DESCRIPTION
## Summary
- Document `multivariate_autocorrelation` in decomposition utilities
- Add debug mode helper docstring and descriptions for event range and visualization helpers
- Explain workflow plotting helpers with detailed parameter docs

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_689b911567308326a5e07338df957936